### PR TITLE
Switch travis-ci build to 64 bit ROOT binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 #  - "3.2"
 
 env:
-  - ROOT=5.34.03
+  - ROOT=5.34.05
   - ROOT=5.32.04
 
 install:
@@ -19,10 +19,10 @@ install:
   # Install the dependencies we need
   - time sudo apt-get install -qq python${PYTHON_SUFFIX}-numpy python${PYTHON_SUFFIX}-sphinx python${PYTHON_SUFFIX}-nose
 
-  # Install a ROOT binary that we custom-built in a 32-bit Ubuntu VM
+  # Install a ROOT binary that we custom-built in a 64-bit Ubuntu VM
   # for the correct Python / ROOT version
   - echo root_v${ROOT}_Python_${TRAVIS_PYTHON_VERSION}.tar.gz
-  - time wget --no-check-certificate https://dl.dropbox.com/u/4923986/rootpy/root_v${ROOT}_Python_${TRAVIS_PYTHON_VERSION}.tar.gz
+  - time wget --no-check-certificate https://dl.dropbox.com/u/4923986/rootpy/64/root_v${ROOT}_Python_${TRAVIS_PYTHON_VERSION}.tar.gz
   - time tar zxf root_v${ROOT}_Python_${TRAVIS_PYTHON_VERSION}.tar.gz
   - source root_v${ROOT}_Python_${TRAVIS_PYTHON_VERSION}/bin/thisroot.sh
 


### PR DESCRIPTION
travis-ci is switching from 32 bit to 64 bit.

Info on how to make the binaries is here:
https://github.com/rootpy/rootpy/wiki/Webserver-and-Continuous-Integration
