### PR TITLE
Fix compatibility with root_numpy and libc++.

### DIFF
--- a/root_numpy/src/BetterChain.h
+++ b/root_numpy/src/BetterChain.h
@@ -22,7 +22,6 @@
 #include "Column.h"
 #include "util.h"
 
-using namespace std;
 
 // Correct TChain implementation with cache TLeaf*
 class BetterChain
@@ -47,7 +46,7 @@ class BetterChain
             }
 
             // Revert branches to their original activated/deactivated state
-            map<string, bool>::iterator status_it;
+            std::map<std::string, bool>::iterator status_it;
             for (status_it = original_branch_status.begin();
                  status_it != original_branch_status.end();
                  ++status_it)
@@ -66,7 +65,7 @@ class BetterChain
             }
 
             // BetterChain owns the formulae and so we delete them here
-            vector<TTreeFormula*>::iterator fit;
+            std::vector<TTreeFormula*>::iterator fit;
             for (fit = formulae.begin(); fit != formulae.end(); ++fit)
             {
                 delete *fit;
@@ -143,7 +142,7 @@ class BetterChain
             // The branches must be activated when a TTreeFormula is initially created.
             TBranch* branch;
             TLeaf* leaf;
-            string bname, lname;
+            std::string bname, lname;
             LeafCache::iterator it;
 
             // Disable all branches
@@ -172,7 +171,7 @@ class BetterChain
 
             // Activate all branches used by the formulae
             int ncodes;
-            vector<TTreeFormula*>::iterator fit;
+            std::vector<TTreeFormula*>::iterator fit;
             for (fit = formulae.begin(); fit != formulae.end(); ++fit)
             {
                 ncodes = (*fit)->GetNcodes();
@@ -216,20 +215,21 @@ class BetterChain
             LeafCache::iterator it;
             for(it = leafcache.begin(); it != leafcache.end(); ++it)
             {
-                string bname = it->first.first;
-                string lname = it->first.second;
+                std::string bname = it->first.first;
+                std::string lname = it->first.second;
                 TBranch* branch = fChain->FindBranch(bname.c_str());
                 if (branch==0)
                 {
-                    cerr << "WARNING cannot find branch " << bname << endl;
+                    std::cerr << "WARNING cannot find branch " << bname
+                              << std::endl;
                     it->second->skipped = true;
                     continue;
                 }
                 TLeaf* leaf = branch->FindLeaf(lname.c_str());
                 if (leaf==0)
                 {
-                    cerr << "WARNING cannot find leaf " << lname
-                         << " for branch " << bname << endl;
+                    std::cerr << "WARNING cannot find leaf " << lname
+                              << " for branch " << bname << std::endl;
                     it->second->skipped = true;
                     continue;
                 }
@@ -238,7 +238,7 @@ class BetterChain
             }
 
             // Update all formula leaves
-            vector<TTreeFormula*>::iterator fit;
+            std::vector<TTreeFormula*>::iterator fit;
             for (fit = formulae.begin(); fit != formulae.end(); ++fit)
             {
                 (*fit)->UpdateFormulaLeaves();
@@ -255,9 +255,9 @@ class BetterChain
             return fChain->GetWeight();
         }
 
-        Column* MakeColumn(const string& bname,
-                           const string& lname,
-                           const string& colname)
+        Column* MakeColumn(const std::string& bname,
+                           const std::string& lname,
+                           const std::string& colname)
         {
             TBranch* branch = fChain->GetBranch(bname.c_str());
             if (branch == NULL)
@@ -312,12 +312,12 @@ class BetterChain
         int fCurrent;
         int ientry;
         MiniNotify* notifier;
-        vector<TTreeFormula*> formulae;
-        map<string, bool> original_branch_status;
+        std::vector<TTreeFormula*> formulae;
+        std::map<std::string, bool> original_branch_status;
 
         // Branch name to leaf name conversion
-        typedef pair<string, string> BL;
-        typedef map<BL, BranchColumn*> LeafCache;
+        typedef std::pair<std::string, std::string> BL;
+        typedef std::map<BL, BranchColumn*> LeafCache;
 
         // Column pointer cache since the leaf inside needs to be updated
         // when new file is loaded in the chain

--- a/root_numpy/src/Column.h
+++ b/root_numpy/src/Column.h
@@ -4,9 +4,7 @@
 #include <TLeaf.h>
 #include <TTreeFormula.h>
 #include <string>
-#include <iostream>
 
-using namespace std;
 
 enum ColumnType{
     SINGLE = 1,
@@ -28,11 +26,11 @@ class Column
         // single fixed vary?
         ColumnType coltype;
         // column name
-        string colname;
+        std::string colname;
         // useful in case of fixed element
         int countval;
         // name of the roottype
-        string rttype;
+        std::string rttype;
 };
 
 
@@ -40,7 +38,7 @@ class FormulaColumn: public Column
 {
     public:
 
-        FormulaColumn(string _colname, TTreeFormula* _formula)
+        FormulaColumn(std::string _colname, TTreeFormula* _formula)
         {
             colname = _colname;
             formula = _formula;
@@ -122,7 +120,7 @@ class BranchColumn: public Column
             else
             {
                 // negative
-                string msg("Unable to understand the structure of leaf ");
+                std::string msg("Unable to understand the structure of leaf ");
                 msg += leaf->GetName();
                 PyErr_SetString(PyExc_IOError, msg.c_str());
                 return 0;
@@ -130,7 +128,7 @@ class BranchColumn: public Column
             return 1;
         }
 
-        static BranchColumn* build(TLeaf* leaf, const string& colname)
+        static BranchColumn* build(TLeaf* leaf, const std::string& colname)
         {
             BranchColumn* ret = new BranchColumn();
             ret->leaf = leaf;


### PR DESCRIPTION
Two header files (Column.h and BetterChain.h) contained 'using namespace
std;' directives.  Not only is this bad practice for C++ _header_ files,
but it also causes compatibility issues with Cython-generated C++ code
when compiling against libc++ (e.g. on Mac OS X 10.9).  The issue arises
due to Cython utility functions using non-namespaced C stdlib functions
(e.g. isspace).  When these two root_numpy headers were included, they
caused an amiguity error by exposing <cctype>'s std::isspace method.
This seems to not have been an issue with GNU libstdc++, but libc++'s
more strict adherence to standards did not like this.

The solution here is simply to prefix all std::-namespace symbols in
these two headers and remove the 'using namespace std;' directives.

One might argue that Cython should std::-prefix their function use, but
the reality is that their routines still need to support C, and their
routines do work if users don't pull in the entire std:: C++ namespace,
so I don't think this is worth commenting about upstream.
