### PR TITLE
rm AUTHORS.rst

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,7 +1,0 @@
-Authors ordered by first contribution:
-
-* Piti Ongmongkolkul (piti118@gmail.com)
-* Noel Dawe (noel@dawe.me)
-* Christoph Deil
-* Peter Waller (p@pwaller.net)
-* Giordon Stark (kratsg@gmail.com, gstark@cern.ch)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,3 @@ recursive-include examples *.py
 include *.py
 include README.rst
 include LICENSE
-include AUTHORS


### PR DESCRIPTION
I prefer not to have a file listing names/emails and instead rely on the git history itself. It can sometimes be difficult to determine at what point someone has contributed enough to be listed as an "author" in this file. Better to just check the git history and get a sense of how much each committer has contributed:

https://github.com/scikit-hep/root_numpy/graphs/contributors