### PR TITLE
Allow saving trees within `TDirectory` structure

### DIFF
--- a/root_numpy/src/tree.pyx
+++ b/root_numpy/src/tree.pyx
@@ -726,6 +726,12 @@ def array2root(arr, filename, treename='tree', mode='update'):
     # If a tree with that name exists, we want to update it
     cdef TTree* tree = <TTree*> rfile.Get(treename)
     tree = array2tree(arr, name=treename, tree=tree)
+    if "/" in treename:
+        components = treename.split("/")
+        dirs = components[:-1]
+        for d in dirs:
+            rfile.mkdir(d).cd()
+        treename = components[-1]
     tree.Write(treename, kOverwrite)
     del tree
     rfile.Close()

--- a/root_numpy/src/tree.pyx
+++ b/root_numpy/src/tree.pyx
@@ -725,13 +725,13 @@ def array2root(arr, filename, treename='tree', mode='update'):
         raise IOError("file {0} is not writable".format(filename))
     # If a tree with that name exists, we want to update it
     cdef TTree* tree = <TTree*> rfile.Get(treename)
-    tree = array2tree(arr, name=treename, tree=tree)
     if "/" in treename:
         components = treename.split("/")
         dirs = components[:-1]
         for d in dirs:
             rfile.mkdir(d).cd()
         treename = components[-1]
+    tree = array2tree(arr, name=treename, tree=tree)
     tree.Write(treename, kOverwrite)
     del tree
     rfile.Close()

--- a/root_numpy/src/tree.pyx
+++ b/root_numpy/src/tree.pyx
@@ -729,8 +729,10 @@ def array2root(arr, filename, treename='tree', mode='update'):
         components = treename.split("/")
         dirs = components[:-1]
         for d in dirs:
+            print d
             rfile.mkdir(d).cd()
         treename = components[-1]
+        print treename
     tree = array2tree(arr, name=treename, tree=tree)
     tree.Write(treename, kOverwrite)
     del tree

--- a/root_numpy/src/tree.pyx
+++ b/root_numpy/src/tree.pyx
@@ -725,12 +725,12 @@ def array2root(arr, filename, treename='tree', mode='update'):
         raise IOError("file {0} is not writable".format(filename))
     # If a tree with that name exists, we want to update it
     cdef TTree* tree = <TTree*> rfile.Get(treename)
-    print treename
+    print(treename)
     if "/" in treename:
         components = treename.split("/")
         dirs = components[:-1]
         for d in dirs:
-            print d
+            print(d)
             rfile.mkdir(d).cd()
         treename = components[-1]
         print treename

--- a/root_numpy/src/tree.pyx
+++ b/root_numpy/src/tree.pyx
@@ -725,6 +725,7 @@ def array2root(arr, filename, treename='tree', mode='update'):
         raise IOError("file {0} is not writable".format(filename))
     # If a tree with that name exists, we want to update it
     cdef TTree* tree = <TTree*> rfile.Get(treename)
+    print treename
     if "/" in treename:
         components = treename.split("/")
         dirs = components[:-1]


### PR DESCRIPTION
Try adding `TDirectory` support when writing a tree directly to a file.
This does not yet support already existing `TDirectory`.

This fixes https://github.com/scikit-hep/root_pandas/issues/45, where trying to save a `DataFrame` with a "/" in the name does not produce a directory structure and can then not be read back using ROOT.