### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,9 @@ language: python
 
 matrix:
     include:
-        - python: 2.7
-          env: PYTHON=2.7 ROOT=5.34.32
-        - python: 2.7
-          env: PYTHON=2.7 ROOT=6.04
-        - python: 3.4
-          env: PYTHON=3.4 ROOT=5.34.32
-        - python: 3.4
-          env: PYTHON=3.4 ROOT=6.04 COVERAGE=1
+        - env: PYTHON=2.7
+        - env: PYTHON=3.6
+        - env: PYTHON=3.7 COVERAGE=1
 
 #install: source ci/install.sh
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,16 @@ matrix:
 install:
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
-  
+
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a # Useful for debugging any issues with conda
-  - conda config --add channels http://conda.anaconda.org/NLeSC  
-  - conda config --set show_channel_urls yes
-  - conda create -q -n testenv python=${PYTHON} root=${ROOT} numpy nose sphinx
+  - conda config --add channels conda-forge/label/gcc7
+  - conda config --add channels chrisburr
+  - conda create -q -n testenv python=${PYTHON} nomkl root nose sphinx
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
   - pip install coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ language: python
 
 matrix:
     include:
-        - env: PYTHON=2.7
-        - env: PYTHON=3.6
+        - env: PYTHON=2.7 COVERAGE=1
+        - env: PYTHON=3.6 COVERAGE=1
         - env: PYTHON=3.7 COVERAGE=1
 
 #install: source ci/install.sh

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,8 @@ test-coverage: in
 	@$(NOSETESTS) -s -v -a '!slow' --with-coverage \
 		--cover-erase --cover-branches \
 		--cover-min-percentage=100 \
-		--cover-html --cover-html-dir=coverage --cover-package=root_numpy
+		--cover-html --cover-html-dir=coverage \
+		--cover-config-file=.coveragerc --cover-package=root_numpy \
 	@if [ "$(INTERACTIVE)" -eq "1" ]; then \
 		$(OPEN) coverage/index.html; \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,7 @@ test-coverage: in
 	@rm -rf coverage .coverage
 	@$(NOSETESTS) -s -v -a '!slow' --with-coverage \
 		--cover-erase --cover-branches \
-		--cover-min-percentage=100 \
-		--cover-html --cover-html-dir=coverage root_numpy
+		--cover-html --cover-html-dir=coverage --cover-package=root_numpy
 	@if [ "$(INTERACTIVE)" -eq "1" ]; then \
 		$(OPEN) coverage/index.html; \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test-coverage: in
 	@$(NOSETESTS) -s -v -a '!slow' --with-coverage \
 		--cover-erase --cover-branches \
 		--cover-min-percentage=100 \
-		--cover-html --cover-html-dir=coverage root_numpy
+		--cover-html --cover-html-dir=coverage --cover-package=root_numpy
 	@if [ "$(INTERACTIVE)" -eq "1" ]; then \
 		$(OPEN) coverage/index.html; \
 	fi;

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,7 @@ test-coverage: in
 	@$(NOSETESTS) -s -v -a '!slow' --with-coverage \
 		--cover-erase --cover-branches \
 		--cover-min-percentage=100 \
-		--cover-html --cover-html-dir=coverage \
-		--cover-config-file=.coveragerc --cover-package=root_numpy \
+		--cover-html --cover-html-dir=coverage root_numpy
 	@if [ "$(INTERACTIVE)" -eq "1" ]; then \
 		$(OPEN) coverage/index.html; \
 	fi;

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -26,5 +26,5 @@ time make test-installed
 if [ ! -z ${COVERAGE+x} ] && [ -z ${NOTMVA+x} ]; then
     # COVERAGE is set and TMVA is included in this build
     # so run the coverage
-    time make test-coverage </dev/null
+    time nosetests --with-coverage --cover-package=root_numpy
 fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -26,5 +26,5 @@ time make test-installed
 if [ ! -z ${COVERAGE+x} ] && [ -z ${NOTMVA+x} ]; then
     # COVERAGE is set and TMVA is included in this build
     # so run the coverage
-    time nosetests --with-coverage --cover-package=root_numpy
+    time make test-coverage </dev/null
 fi


### PR DESCRIPTION
I've created some new conda packages for ROOT. They're still experimental as they're dependent on the new compiler infrastructure in Anaconda 5, see https://github.com/scikit-hep/uproot/pull/183 for more details.

This should fix the build again, though it does drop testing against Python 3.4 and ROOT 5.