### PR TITLE
Add missing import

### DIFF
--- a/root_numpy/setup_utils.py
+++ b/root_numpy/setup_utils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import re
 import subprocess
 import numbers


### PR DESCRIPTION
`sys` is used by `setup_utils.py` but never imported