### PR TITLE
Don't delete os.link in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,6 @@ import os
 from glob import glob
 from contextlib import contextmanager
 
-# Prevent setup from trying to create hard links
-# which are not allowed on AFS between directories.
-# This is a hack to force copying.
-try:
-    del os.link
-except AttributeError:
-    pass
-
 local_path = os.path.dirname(os.path.abspath(__file__))
 # setup.py can be called from outside the root_numpy directory
 os.chdir(local_path)


### PR DESCRIPTION
Causes installation to fail with newer version of `numpy` (traceback below) and I'm not convinced it's needed.

```
Processing /Users/.../root_numpy_1574437817460/work
  Created temporary directory: /private/var/folders/m4/ny3rx96n7j97182lb50mh8mc0000gn/T/pip-req-build-l8h7z4fa
  Added file:///Users/.../root_numpy_1574437817460/work to build tracker '/private/var/folders/m4/ny3rx96n7j97182lb50mh8mc0000gn/T/pip-req-tracker-k_en1d3n'
    Running setup.py (path:/private/var/folders/m4/ny3rx96n7j97182lb50mh8mc0000gn/T/pip-req-build-l8h7z4fa/setup.py) egg_info for package from file:///Users/.../root_numpy_1574437817460/work
    Running command python setup.py egg_info
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/m4/ny3rx96n7j97182lb50mh8mc0000gn/T/pip-req-build-l8h7z4fa/setup.py", line 242, in <module>
        setup_package()
      File "/private/var/folders/m4/ny3rx96n7j97182lb50mh8mc0000gn/T/pip-req-build-l8h7z4fa/setup.py", line 178, in setup_package
        import numpy
      File "/Users/.../lib/python3.8/site-packages/numpy/__init__.py", line 142, in <module>
        from . import core
      File "/Users/.../lib/python3.8/site-packages/numpy/core/__init__.py", line 17, in <module>
        from . import multiarray
      File "/Users/.../lib/python3.8/site-packages/numpy/core/multiarray.py", line 14, in <module>
        from . import overrides
      File "/Users/.../lib/python3.8/site-packages/numpy/core/overrides.py", line 9, in <module>
        from numpy.compat._inspect import getargspec
      File "/Users/.../lib/python3.8/site-packages/numpy/compat/__init__.py", line 14, in <module>
        from . import py3k
      File "/Users/.../lib/python3.8/site-packages/numpy/compat/py3k.py", line 16, in <module>
        from pathlib import Path, PurePath
      File "/Users/.../lib/python3.8/pathlib.py", line 390, in <module>
        class _NormalAccessor(_Accessor):
      File "/Users/.../lib/python3.8/pathlib.py", line 414, in _NormalAccessor
        link_to = os.link
    AttributeError: module 'os' has no attribute 'link'
```